### PR TITLE
This patch will fix _menu_translate so it no loinger produces a warning.

### DIFF
--- a/patches/menu-undefined-offset-1108314.patch
+++ b/patches/menu-undefined-offset-1108314.patch
@@ -1,0 +1,32 @@
+Index: includes/menu.inc
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- includes/menu.inc	(revision )
++++ includes/menu.inc	(revision )
+@@ -773,14 +773,16 @@
+     $tab_parent_map = explode('/', $router_item['tab_parent']);
+   }
+   for ($i = 0; $i < $router_item['number_parts']; $i++) {
++    if (isset($path_map[$i])){
+-    if ($link_map[$i] == '%') {
+-      $link_map[$i] = $path_map[$i];
+-    }
+-    if (isset($tab_root_map[$i]) && $tab_root_map[$i] == '%') {
+-      $tab_root_map[$i] = $path_map[$i];
+-    }
+-    if (isset($tab_parent_map[$i]) && $tab_parent_map[$i] == '%') {
+-      $tab_parent_map[$i] = $path_map[$i];
++      if ($link_map[$i] == '%') {
++        $link_map[$i] = $path_map[$i];
++      }
++      if (isset($tab_root_map[$i]) && $tab_root_map[$i] == '%') {
++        $tab_root_map[$i] = $path_map[$i];
++      }
++      if (isset($tab_parent_map[$i]) && $tab_parent_map[$i] == '%') {
++        $tab_parent_map[$i] = $path_map[$i];
++      }
+     }
+   }
+   $router_item['href'] = implode('/', $link_map);


### PR DESCRIPTION
When visiting a search page with no search term, many notices are show:

Notice: Undefined offset: 2 in _menu_translate() (line 777 of /var/www/drupal/dgud7/build_42/includes/menu.inc).
Notice: Undefined offset: 2 in _menu_translate() (line 780 of /var/www/drupal/dgud7/build_42/includes/menu.inc).

This is caused by apachesolr_search module (correctly using a % in the path for the menu_local_task) which Drupal then seems to want to translate even thought he wild card has been dropped from the path map. This causes the above notice.
