### PR TITLE
Added /user to disallowed urls

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -42,6 +42,7 @@ Disallow: /user/register/
 Disallow: /user/password/
 Disallow: /user/login/
 Disallow: /user/logout/
+Disallow: /user
 # Paths (no clean URLs)
 Disallow: /?q=admin/
 Disallow: /?q=comment/reply/


### PR DESCRIPTION
Googlebot is generating a lot of traffic like:

GET /user?destination=http://data.gov.uk/data/search?dataset-results-sort=/data/search%3Ftags%3Dsafety%26tags%3Dprisons%26sort%3Dmetadata_modified%2Bdesc HTTP/1.1

a. This is a broken url
b. They're hitting the login link and they shouldn't.
