### PR TITLE
When the operation is create, the node type is passed to node_access 

### DIFF
--- a/modules/features/dgu_data_set_request/dgu_data_set_request.module
+++ b/modules/features/dgu_data_set_request/dgu_data_set_request.module
@@ -78,8 +78,8 @@ function dgu_data_set_request_exit() {
   }
 }
 
-function dgu_data_set_request_node_access($node) {
-  if ($node->type == 'dataset_request' && isset($node->field_publication_preference[LANGUAGE_NONE][0]['value']) && $node->field_publication_preference[LANGUAGE_NONE][0]['value'] == 0) {
+function dgu_data_set_request_node_access($node, $op, $account) {
+  if ($op != 'create' && $node->type == 'dataset_request' && isset($node->field_publication_preference[LANGUAGE_NONE][0]['value']) && $node->field_publication_preference[LANGUAGE_NONE][0]['value'] == 0) {
     return NODE_ACCESS_DENY;
   }
 }


### PR DESCRIPTION
instead of a node instance. This fixes an error when trying to create a new dsr.
