### PR TITLE
Add solrsort to search form and use score as the default sort 

### DIFF
--- a/modules/features/dgu_search/dgu_search.module
+++ b/modules/features/dgu_search/dgu_search.module
@@ -133,6 +133,10 @@ function dgu_search_search_block($form, &$form_state) {
     '#type' => 'hidden',
     '#value' => $form_state['searchtype'],
   );
+  $form['solrsort'] = array(
+    '#type' => 'hidden',
+    '#value' => $form_state['solrsort'],
+  );
   $form['count'] = array(
     '#type' => 'hidden',
     '#value' => $form_state['count'],
@@ -218,12 +222,21 @@ function dgu_search_form_search_block_form_submit($form, &$form_state) {
       }
     }
 
+    $solrsort = '';
+    if (isset($fv['solrsort']) ){
+      if ($facets)
+        $solrsort = "";
+      else
+        $solrsort = "?";
+      $solrsort = $solrsort . "solrsort=${fv['solrsort']}";
+    }
+
     // Replace keys with their rawurlencoded value
     $raw_keys = str_replace("/","%2f",$fv['search_block_form']);
 
     // Override redirect with a new bundle specific search.
     global $base_url;
-    $form_state['redirect'] =  $base_url."/search/everything/" . $raw_keys . $facets;
+    $form_state['redirect'] =  $base_url."/search/everything/" . $raw_keys . $facets . $solrsort;
   }
 }
 

--- a/modules/features/dgu_search/plugins/content_types/dgu_search_form.inc
+++ b/modules/features/dgu_search/plugins/content_types/dgu_search_form.inc
@@ -43,9 +43,8 @@ function dgu_search_dgu_search_form_content_type_render($subtype, $conf, $panel_
     'start' => 0,
     'keys' => '',
     'filters' => isset($_GET['filters']) ? $_GET['filters'] : '',
-    'sort' => isset($_GET['solrsort']) ? $_GET['solrsort'] : '',
+    'sort' => isset($_GET['solrsort']) ? $_GET['solrsort'] : 'score',
   );
-
   // Use keywords from the selected context if set to do so.
   if (!empty($context) && !empty($context->data)) {
     $search['keys'] = $context->data;
@@ -60,6 +59,7 @@ function dgu_search_dgu_search_form_content_type_render($subtype, $conf, $panel_
     $form_state['searchtype'] = '';
     $search['filters'] = empty($_GET['f'])? array() : $_GET['f'];
     $form_state['f'] = $search['filters'];
+
   } else {
     $form_state['content_type'] = $search_types[$conf['content_type']];
     $form_state['searchtype'] = $conf['content_type'];
@@ -121,7 +121,7 @@ function dgu_search_dgu_search_form_content_type_render($subtype, $conf, $panel_
     $dr_count = $result->fetchField();
     $form_state['dataset_request_count'] = $dr_count;
   }
-
+  $form_state['solrsort'] = $solrsort;
   $form = drupal_build_form('dgu_search_form', $form_state);
 
   // Statcically cached keyword in dgu_search.module:dgu_search_apachesolr_query_prepare()

--- a/modules/features/dgu_search/templates/dgu_search_form.tpl.php
+++ b/modules/features/dgu_search/templates/dgu_search_form.tpl.php
@@ -18,6 +18,7 @@
             <input type="hidden" name="f[<?php print $i; ?>]" value="<?php print $value ?>">
             <?php endforeach ?>
             <input type="hidden" name="searchtype" value="<?php print $form['searchtype']['#value'] ?>">
+            <input type="hidden" name="solrsort" value="<?php print $form['solrsort']['#value'] ?>">
             <input type="hidden" name="submit" value="search">
           </form>
         </div>


### PR DESCRIPTION
Any searches where there the search form is submitted, the default sort order is now score, which is a much less surprising default than changed_ds.
