### PR TITLE
Add empty() to theme_dgu_search_select to fix undefined variable error

### DIFF
--- a/modules/features/dgu_search/dgu_search.module
+++ b/modules/features/dgu_search/dgu_search.module
@@ -426,7 +426,7 @@ function theme_dgu_search_select($options) {
   $output .= '<select name="search-results-sort" class="form-control">';
   $select_options = $options['select_options'];
   foreach ($select_options as $key => $values) {
-    $disabled =  empty($values['disabled']) ? ' disabled="disabled" ' : '';
+    $disabled =  empty($values['disabled']) ? '' : ' disabled="disabled" ';
     $selected =  $values['selected'] ? ' selected="selected" ' : '';
     $output .= '<option value="' . $key . '"' . $selected . $disabled .  '>' . $values['text'] . '</option>';
   }


### PR DESCRIPTION
Error produced on the /forum section when performing an empty search.
