### PR TITLE
Change lock icon to a wrench

### DIFF
--- a/themes/custom/dguk/templates/page.tpl.php
+++ b/themes/custom/dguk/templates/page.tpl.php
@@ -60,7 +60,7 @@
 
           <?php if ($user->uid == 1 || in_array('data publisher', array_values($user->roles))): ?>
             <span class="dropdown">
-              <a class="nav-publisher btn btn-info dropdown-button" data-toggle="dropdown" href="#"><i class="icon-lock"></i></a>
+              <a class="nav-publisher btn btn-info dropdown-button" data-toggle="dropdown" href="#"><i class="icon-wrench"></i></a>
               <ul class="dropdown-menu dgu-user-dropdown" role="menu" aria-labelledby="dLabel">
                 <li role="presentation" class="dropdown-header">Tools</li>
                 <li><a href="/dataset/new">Add a Dataset</a></li>


### PR DESCRIPTION
It has been suggested that the lock icon be replaced with a wrench.

If/when we merge/deploy this then the CKAN site will also need doing at the same time.

https://github.com/datagovuk/ckanext-dgu/pull/103